### PR TITLE
Update xbacklight-ctl

### DIFF
--- a/xbacklight-ctl
+++ b/xbacklight-ctl
@@ -85,7 +85,7 @@ backlight_up () {
 
 	local PERC=${1:-$PERC}
 
-	local CURR_PERC=`xbacklight | sed "s/\..*//g"`
+	local CURR_PERC=`xbacklight -get`
 	[[ $(($CURR_PERC+$PERC)) -gt $MAX ]] && local PERC=$(($MAX-$CURR_PERC))
 	local NEW_PERC=$(($CURR_PERC+$PERC))
 
@@ -98,7 +98,7 @@ backlight_down () {
 
 	local PERC=${1:-$PERC}
 
-	local CURR_PERC=`xbacklight | sed "s/\..*//g"`
+	local CURR_PERC=`xbacklight -get`
 	[[ $(($CURR_PERC-$PERC)) -lt $MIN ]] && local PERC=$(($CURR_PERC-$MIN))
 	local NEW_PERC=$(($CURR_PERC-$PERC))
 


### PR DESCRIPTION
Hi,

I guess there has been a change in xbacklight, as now your script returns xbacklight's usage text and some functionality does not work. Replacing the two instances of `xbacklight | sed "s/\..*//g"` with `xbacklight -get` resolves this. 
